### PR TITLE
共例句囥佇placeholder，若是揤space抑是正爿／下跤箭頭，才共例句貼落去

### DIFF
--- a/src/頁/查/查表格.jsx
+++ b/src/頁/查/查表格.jsx
@@ -72,10 +72,22 @@ class 查表格 extends React.Component {
         {menu}
 
         <div className="app block">
-          <textarea defaultValue={語句}
+          <textarea
+            placeholder={語句}
             ref={(c) => { this.refText = c; }}
-            rows='3' />
+            rows='3'
+            onKeyDown={(event) => {
+              if (event.keyCode === 32 || event.keyCode === 39) {
+                event.preventDefault(); // prevent space from being added to text
+                this.refText.value = this.refText.getAttribute('placeholder');
+                this.refText.removeAttribute('placeholder');
+              }
+            }}
+          />
         </div>
+
+
+
 
         <div className="app clearing">
           <button className={

--- a/src/頁/查/查表格.jsx
+++ b/src/頁/查/查表格.jsx
@@ -77,11 +77,10 @@ class 查表格 extends React.Component {
             ref={(c) => { this.refText = c; }}
             rows='3'
             onKeyDown={(event) => {
-              const allowedKeyCodes = [32, 39];
-              if (allowedKeyCodes.includes(event.keyCode) && this.refText.value === "") {
-                event.preventDefault(); // prevent space or right arrow from being added to text
+              const allowedKeyCodes = [32, 39, 40]; //若是揤space、正爿箭頭抑是下跤箭頭，才共placeholder的文字貼入去
+              if (this.refText.value === "" && allowedKeyCodes.includes(event.keyCode)) {
+                event.preventDefault(); // 莫共space、正爿箭頭抑是下跤箭頭的動作嘛貼落去
                 this.refText.value = this.refText.getAttribute('placeholder');
-                this.refText.removeAttribute('placeholder');
               }
             }}
           />

--- a/src/頁/查/查表格.jsx
+++ b/src/頁/查/查表格.jsx
@@ -77,17 +77,15 @@ class 查表格 extends React.Component {
             ref={(c) => { this.refText = c; }}
             rows='3'
             onKeyDown={(event) => {
-              if (event.keyCode === 32 || event.keyCode === 39) {
-                event.preventDefault(); // prevent space from being added to text
+              const allowedKeyCodes = [32, 39];
+              if (allowedKeyCodes.includes(event.keyCode) && this.refText.value === "") {
+                event.preventDefault(); // prevent space or right arrow from being added to text
                 this.refText.value = this.refText.getAttribute('placeholder');
                 this.refText.removeAttribute('placeholder');
               }
             }}
           />
         </div>
-
-
-
 
         <div className="app clearing">
           <button className={


### PR DESCRIPTION
臺語工程師群組內底有人建議，例句無一定愛一開始就囥佇內底，無逐遍攏愛刣掉才閣拍家己欲查的文字。
若是揤space抑是正爿／下跤箭頭才共例句貼落去，使用者的體驗應該會較好。